### PR TITLE
altered yellorium ingot/block costs

### DIFF
--- a/src/main/java/com/drullkus/thermalsmeltery/common/plugins/tcon/smeltery/TConSmeltery.java
+++ b/src/main/java/com/drullkus/thermalsmeltery/common/plugins/tcon/smeltery/TConSmeltery.java
@@ -38,11 +38,11 @@ public class TConSmeltery
 				//Ingot
 				tableCasting.addCastingRecipe(
                         new ItemStack(GameRegistry.findItem("BigReactors", "BRIngot"), 1, 0),
-                        new FluidStack(FluidRegistry.getFluid("yellorium"), 1000), ingotcast, 50);
+                        new FluidStack(FluidRegistry.getFluid("yellorium"), 144), ingotcast, 50);
 				//Basin
 				basinCasting.addCastingRecipe(
                         new ItemStack(GameRegistry.findBlock("BigReactors", "BRMetalBlock"), 1, 0),
-                        new FluidStack(FluidRegistry.getFluid("yellorium"), 9000), 450);
+                        new FluidStack(FluidRegistry.getFluid("yellorium"), 1296), 450);
 			}
 
 			if (TSmeltConfig.TConSteelRecipe&& FluidRegistry.getFluid("coal") != null)


### PR DESCRIPTION
regarding issue 24
(https://github.com/Drullkus/ThermalSmeltery/issues/24)
If you wanted each yellorium ingot to give the standard metal ingot value, and wanted the yellorium blocks to cost the standard value, I believe this fixes it.
