### PR TITLE
Fixes #31

### DIFF
--- a/src/main/java/us/drullk/thermalsmeltery/common/Compat.java
+++ b/src/main/java/us/drullk/thermalsmeltery/common/Compat.java
@@ -16,7 +16,7 @@ public class Compat {
         for (MeltingRecipe recipe : smelteryMap) {
             for (ItemStack entry : recipe.input.getInputs())
             {
-                if (!(entry.getItem() instanceof ToolPart))
+                if (entry != null && !(entry.getItem() instanceof ToolPart))
                 {
                     int energy = recipe.getTemperature() * TSmeltConfig.rfCostMultiplier; // Calculate temperature to energy here
                     addCrucibleRecipe(energy, entry, recipe.getResult());

--- a/src/main/java/us/drullk/thermalsmeltery/common/Compat.java
+++ b/src/main/java/us/drullk/thermalsmeltery/common/Compat.java
@@ -2,7 +2,7 @@ package us.drullk.thermalsmeltery.common;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.*;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
 import slimeknights.tconstruct.library.smeltery.MeltingRecipe;
 import slimeknights.tconstruct.library.tools.ToolPart;
@@ -27,11 +27,11 @@ public class Compat {
 
     private static void addCrucibleRecipe(int energy, ItemStack input, FluidStack output)
     {
-        if (input == null || output == null)
+        if (input == null || output == null || FluidRegistry.getFluidName(output) == null)
         {
             return;
         }
-
+        
         NBTTagCompound message = new NBTTagCompound();
 
         message.setInteger("energy", energy);


### PR DESCRIPTION
This should fix #31. The reason that the game was crashing was because whenever two mods register a fluid with the same name, Forge treats them as the same fluid; this prevents duplicate fluids, but one of them would return null for FluidRegistry.getFluidName; the null name would cause a crash. This fix should still allow all of the (non-duplicate) crucible recipes to be registered while fixing the crash.
(I have already tested this fix to work.)